### PR TITLE
Set dark mode by default

### DIFF
--- a/src/core/apollo/variables.js
+++ b/src/core/apollo/variables.js
@@ -1,7 +1,21 @@
 import { makeVar } from "@apollo/client";
 
-export const darkModeVar = makeVar(
-  typeof localStorage !== "undefined"
-    ? localStorage.getItem("darkMode") === "true"
-    : false
-);
+const getDarkModeVar = () => {
+  if (typeof localStorage !== "undefined") {
+    const isDarkMode = localStorage.getItem("darkMode");
+
+    // Set dark mode by default
+    if (isDarkMode === null) {
+      document.documentElement.classList.add(["dark-theme"]);
+      document.documentElement.style.color = "#FFFFFF";
+      localStorage.setItem("darkMode", "true")
+      return true;
+    }
+
+    return isDarkMode === "true";
+  }
+  
+  return false;
+};
+
+export const darkModeVar = makeVar(getDarkModeVar());


### PR DESCRIPTION
The PR sets dark mode by default. 

It sets the **darkMode** variable to **"true"** in **localStorage** if it is not set yet.

Closes #14 