### PR TITLE
Sort by TVL by default

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -130,9 +130,9 @@ function IndexPage() {
 
         <Grid item xs={12}>
           <PoolTable
-            title="Top Sushi Reward Pools"
+            title="Sushi Reward Pools"
             pools={pools}
-            orderBy="rewardPerThousand"
+            orderBy="tvl"
             order="desc"
             rowsPerPage={25}
           />


### PR DESCRIPTION
Show users the impressive statistics by default (20% ROI on ETH-WBTC , 60% on SUSHI-ETH...) instead of showing pools with the highest reward (230% oneVBTC-WETH - which only has 50k liquidity) which aren't as interesting to most users.