### PR TITLE
Added quicksushi endpoint as hotfix for delayed subgraph

### DIFF
--- a/src/core/apollo/link.js
+++ b/src/core/apollo/link.js
@@ -13,7 +13,7 @@ export const uniswap = from([
 export const exchange = from([
   new RetryLink(),
   new HttpLink({
-    uri: "https://api.thegraph.com/subgraphs/name/jiro-ono/matic-exchange-staging",
+    uri: "https://api.thegraph.com/subgraphs/name/medariox/quicksushi",
     shouldBatch: true,
   }),
 ]);


### PR DESCRIPTION
Using QuickSushi Graph Endpoint: 

https://thegraph.com/explorer/subgraph/medariox/quicksushi

Missing full history, and maybe a couple of whitelisted tokens. But this will be sufficient to use for polygon analytics while we wait for prod subgraphs to catch up.