### PR TITLE
Fixed queries to show missing pairs that were being filtered

### DIFF
--- a/src/core/queries/exchange.js
+++ b/src/core/queries/exchange.js
@@ -257,7 +257,7 @@ export const pairSubsetQuery = gql`
 export const pairsQuery = gql`
   query pairsQuery(
     $first: Int! = 1000
-    $orderBy: String! = "trackedReserveETH"
+    $orderBy: String! = "reserveUSD"
     $orderDirection: String! = "desc"
   ) {
     pairs(first: $first, orderBy: $orderBy, orderDirection: $orderDirection) {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -129,6 +129,14 @@ function IndexPage() {
         </Grid>
 
         <Grid item xs={12}>
+          <PairTable title="Top Sushi Liquidity Pairs" pairs={pairs} />
+        </Grid>
+
+        <Grid item xs={12}>
+          <TokenTable title="Top Tokens" tokens={tokens} />
+        </Grid>
+
+        <Grid item xs={12}>
           <PoolTable
             title="Sushi Reward Pools"
             pools={pools}
@@ -136,14 +144,6 @@ function IndexPage() {
             order="desc"
             rowsPerPage={25}
           />
-        </Grid>
-
-        <Grid item xs={12}>
-          <PairTable title="Top Sushi Liquidity Pairs" pairs={pairs} />
-        </Grid>
-
-        <Grid item xs={12}>
-          <TokenTable title="Top Tokens" tokens={tokens} />
         </Grid>
       </Grid>
     </AppShell>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -73,7 +73,7 @@ function IndexPage() {
         });
         previousValue[1].unshift({
           date: currentValue.date,
-          value: parseFloat(currentValue.volumeUSD),
+          value: parseFloat(currentValue.untrackedVolume),
         });
         return previousValue;
       },


### PR DESCRIPTION
Pairs that had 0 trackedReserveETH where getting filtered out by sorting on that property. Switched it to use reserveUSD instead.

Also using untrackedVolume for the overall volume calculation seems to pick up on those missed pairs that don't get their volume tracked.